### PR TITLE
changed key generation to make pem files

### DIFF
--- a/xbps-mini-builder
+++ b/xbps-mini-builder
@@ -6,7 +6,7 @@ cd "${0%/*}" || exit 1
 # Do we have keys to sign with?
 if [ ! -f id_rsa ] ; then
     rm -rf id_rsa id_rsa.pub
-    ssh-keygen -b 4096 -t rsa -N "" -f id_rsa
+    ssh-keygen -b 4096 -t rsa -m PEM -N "" -f id_rsa
 fi
 
 # Remove old state


### PR DESCRIPTION
I might be missing something, but I just could not get xbps-rindex to work with the files being generated from this script. I then read in the xbps manual and it was using PEM when generating keys, and when I added that it worked right away.

Again, I don't know if this is just a personal issue, but this is how I fixed it for myself.