### PR TITLE
Giving multiple arguments causes an error

### DIFF
--- a/xbps-mini-builder
+++ b/xbps-mini-builder
@@ -58,7 +58,7 @@ if [ -f ../xbps-src.conf ] ; then
     cat ../xbps-src.conf >> etc/conf
 fi
 
-if [ -z "$@" ] ; then
+if [ -z "$*" ] ; then
     while read -r package ; do
         if grep "${package}" ../changed; then
             ./xbps-src pkg "${package}"


### PR DESCRIPTION
Normally quoting a string will prevent word-splitting, but `$@` is (weirdly) a special case and it will give unexpected arguments to `[` which will cause an error like this:
`./xbps-mini-builder: 61: [: <package name>: unexpected operator`

`$*` is equivalent to `$@` but without this weird behavior.

I recommend using shellcheck to lint your shell code, it will catch stuff like this (also adding `set -e` to the top of your scripts will prevent errors like this one from being trampled over).